### PR TITLE
Update runtime to 5.15-21.08 (supported)

### DIFF
--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -1,6 +1,6 @@
 app-id: io.github.antimicrox.antimicrox
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
 command: antimicrox
 finish-args:


### PR DESCRIPTION
When updating antimicrox, I saw this message:

```
Info: org.kde.Platform//5.15 is end-of-life, with reason:
   We strongly recommend moving to the latest stable version of the Plaform and SDK
```

As:
- org.kde.Platform//5.15 is EOL
- org.kde.Platform//6.2 uses Qt6, not Qt5
- org.kde.Platform//5.15-21.08 is an updated runtime with Qt5

...the easiest fix is to update to 5.15-21.08.